### PR TITLE
Persist away message data in the address bar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -131,6 +131,25 @@ const DEFAULTS = {
   },
 };
 
+function parseUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const state = params.get("state");
+  if (state) {
+    try {
+      return JSON.parse(decodeURIComponent(state));
+    } catch (e) {
+      console.error("Failed to parse state from URL", e);
+    }
+  }
+  return null;
+}
+
+function updateUrl(state: EditorState) {
+  const params = new URLSearchParams(window.location.search);
+  params.set("state", encodeURIComponent(JSON.stringify(state)));
+  window.history.replaceState({}, "", `${window.location.pathname}?${params}`);
+}
+
 export default function Home() {
   const [state, setState] = useState<EditorState>(DEFAULTS.default.value);
 
@@ -186,6 +205,17 @@ export default function Home() {
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState({ ...state, value: e.target.value });
   };
+
+  useEffect(() => {
+    const initialState = parseUrl();
+    if (initialState) {
+      setState(initialState);
+    }
+  }, []);
+
+  useEffect(() => {
+    updateUrl(state);
+  }, [state]);
 
   return (
     <main

--- a/app/style.css
+++ b/app/style.css
@@ -105,7 +105,7 @@ table {
 
 fieldset {
   display: flex;
-  padding: 0;
+  padding: 0 !important;
   min-inline-size: 0;
 }
 


### PR DESCRIPTION
Related to #1

Persist away message data in the address bar.

* Add a function `parseUrl` to parse the URL and extract the away message data.
* Add a function `updateUrl` to update the URL with the current away message data.
* Update the `useEffect` hook to read away message data from the URL on initial load.
* Update the `useEffect` hook to update the URL whenever the away message data changes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jdan/away-message/issues/1?shareId=70e98a8e-4888-4ee2-9d07-e6837130e5a6).