### PR TITLE
Fieldset rule in style.css is appearing out of order with 98.css import

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -105,7 +105,7 @@ table {
 
 fieldset {
   display: flex;
-  padding: 0;
+  padding: 0 !important;
   min-inline-size: 0;
 }
 


### PR DESCRIPTION
Related to #5

Add `!important` to the `padding: 0` declaration in the `fieldset` rule in `app/style.css` to prevent padding from `98.css` import.

* Modify `fieldset` rule in `app/style.css` to include `padding: 0 !important`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jdan/away-message/issues/5?shareId=4bd28d70-a499-43a8-88c0-d3679c2fd8c2).